### PR TITLE
| Add-bought-ship-card-to-the-discard-pile

### DIFF
--- a/server/src/utils/common.ts
+++ b/server/src/utils/common.ts
@@ -13,9 +13,11 @@ export function handleShipPurchase(card: ShipCard) {
   // e.g. if ship gives 3 coins, remove 3 cards from the deck, because they're given to the player's coin deck
   const newPrimaryPile = shuffled.slice(coinAmount)
   const newCurrentPlayerCards = shuffled.slice(0, coinAmount)
-
   // set the current deck to the right one
   gameStatus.cards.primaryPile = newPrimaryPile
+
+  //move the bought ship card to the discard pile
+  gameStatus.cards.discardPile = [...gameStatus.cards.discardPile, card]
   currentPlayer.coins += coinAmount
   currentPlayer.cards = currentPlayer.cards.concat(newCurrentPlayerCards)
 


### PR DESCRIPTION
Siirretään ostettu laivakortti -> `discardPile`en